### PR TITLE
Test cases review

### DIFF
--- a/test/accuracy/main.cpp
+++ b/test/accuracy/main.cpp
@@ -24,15 +24,8 @@ uint8_t counter = 0;
 
 void printTime()
 {
-    if (counter++ < 10)
-    {
-        printf("*");
-        fflush(stdout);
-    }
-    else
-    {
-        MBED_HOSTTEST_RESULT(true);
-    }
+    printf("*");
+    fflush(stdout);
 }
 
 void app_start(int, char *[])

--- a/test/calendar/main.cpp
+++ b/test/calendar/main.cpp
@@ -21,8 +21,11 @@
 
 #include <sys/time.h>
 
-
+namespace {
+char buffer[32] = {0};
+time_t seconds;
 uint8_t counter = 0;
+}
 
 void endTime()
 {
@@ -31,19 +34,9 @@ void endTime()
 
 void printTime()
 {
-    if (counter++ < 5)
-    {
-        char buffer[32] = {0};
-        time_t seconds = time(NULL);
-
-        strftime(buffer, 32, "%Y-%m-%d %H:%M:%S %p", localtime(&seconds));
-        printf("MBED: [%ld] [%s]\r\n", seconds, buffer);
-    }
-    else
-    {
-        MBED_HOSTTEST_RESULT(true);
-    }
-
+    seconds = time(NULL);
+    strftime(buffer, 32, "%Y-%m-%d %H:%M:%S %p", localtime(&seconds));
+    printf("MBED: [%ld] [%s]\r\n", seconds, buffer);
 }
 
 void app_start(int, char *[])

--- a/test/overflow/main.cpp
+++ b/test/overflow/main.cpp
@@ -21,8 +21,9 @@
 
 #include <sys/time.h>
 
-
-time_t unixtime;
+namespace {
+static time_t unixtime;
+}
 
 void endTime()
 {


### PR DESCRIPTION
- You do not always have to have `MBED_HOSTTEST_RESULT();` macro in your c++ test source. For RTC and timer test case, host test makes decision if test passed of failed (by measuring time between prints).
- I would reconsider checking overflow by not going from:
  - `0` -> `overflow_time` but from 
  - (`overflow_time` - `10-15 sec`) -> (`overflow_time`).
    It will allow us to run this test case is few seconds in CI in regression.
